### PR TITLE
TLS 1.3 PSK Implementation in kritis3m_asl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ option(KRITIS3M_ASL_ENABLE_PKCS11 "Enable PKCS11 support" ON)
 
 # Enable support for the PQC signature algorithm FALCON (FN-DSA) via the additional
 # library liboqs. When disabled, the library will not be built.
-option(KRITIS3M_ASL_ENABLE_FALCON "Enable FALCON (FN-DSA) signature algorithm" ON)
+option(KRITIS3M_ASL_ENABLE_FALCON "Enable FALCON (FN-DSA) signature algorithm" OFF)
 
 # Enable direct access to the WolfSSL API
 option(KRITIS3M_ASL_INTERNAL_API "Enable access to internal WolfSSL API" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ option(KRITIS3M_ASL_ENABLE_PKCS11 "Enable PKCS11 support" ON)
 
 # Enable support for the PQC signature algorithm FALCON (FN-DSA) via the additional
 # library liboqs. When disabled, the library will not be built.
-option(KRITIS3M_ASL_ENABLE_FALCON "Enable FALCON (FN-DSA) signature algorithm" OFF)
+option(KRITIS3M_ASL_ENABLE_FALCON "Enable FALCON (FN-DSA) signature algorithm" ON)
 
 # Enable direct access to the WolfSSL API
 option(KRITIS3M_ASL_INTERNAL_API "Enable access to internal WolfSSL API" OFF)

--- a/include/asl.h
+++ b/include/asl.h
@@ -64,8 +64,9 @@ typedef void (*asl_log_callback_t)(int32_t level, char const* message);
 typedef unsigned int (*asl_psk_client_callback_t)(char* key, char* identity);
 
 /* Function pointer type for server psk. */
-typedef unsigned int (*asl_psk_server_callback_t)(char* key, const char* identity, const char** ciphersuite);
-
+typedef unsigned int (*asl_psk_server_callback_t)(char* key,
+                                                  const char* identity,
+                                                  const char** ciphersuite);
 
 /* Data structure for the library configuration. */
 typedef struct

--- a/include/asl.h
+++ b/include/asl.h
@@ -64,7 +64,7 @@ typedef void (*asl_log_callback_t)(int32_t level, char const* message);
 typedef unsigned int (*asl_psk_client_callback_t)(char* key, char* identity);
 
 /* Function pointer type for server psk. */
-typedef unsigned int (*asl_psk_server_callback_t)(char* key, const char* identity, const char* ciphersuite);
+typedef unsigned int (*asl_psk_server_callback_t)(char* key, const char* identity, const char** ciphersuite);
 
 
 /* Data structure for the library configuration. */

--- a/include/asl.h
+++ b/include/asl.h
@@ -45,6 +45,7 @@ enum ASL_ERROR_CODES
         ASL_CONN_CLOSED = -6,
         ASL_WANT_READ = -7,
         ASL_WANT_WRITE = -8,
+        ASL_PSK_ERROR = -9,
 };
 
 /* Available Log levels. Default is ERR. */
@@ -56,10 +57,17 @@ enum ASL_LOG_LEVEL
         ASL_LOG_LEVEL_DBG = 4U,
 };
 
-/* Function pointer type fo logging callbacks. */
+/* Function pointer type for logging callbacks. */
 typedef void (*asl_log_callback_t)(int32_t level, char const* message);
 
-/* Data structure for the library configuration */
+/* Function pointer type for client psk. */
+typedef unsigned int (*asl_psk_client_callback_t)(char* key, char* identity);
+
+/* Function pointer type for server psk. */
+typedef unsigned int (*asl_psk_server_callback_t)(char* key, const char* identity, const char* ciphersuite);
+
+
+/* Data structure for the library configuration. */
 typedef struct
 {
         bool logging_enabled;
@@ -104,6 +112,14 @@ typedef struct
                 bool use_for_all;
 
         } pkcs11;
+
+        struct
+        {
+                asl_psk_client_callback_t psk_client_cb;
+                asl_psk_server_callback_t psk_server_cb;
+                bool enable_psk;
+
+        } psk;
 
         struct
         {

--- a/src/asl.c
+++ b/src/asl.c
@@ -327,10 +327,9 @@ static inline unsigned int wolfssl_tls13_client_cb(WOLFSSL* ssl, const char* hin
         return key_len;
 }
 
-static inline unsigned int wolfssl_tls13_server_cb(WOLFSSL* ssl, const char* hint, 
-                                                   char* identity, unsigned int id_max_len,
-                                                   unsigned char* key, unsigned int key_max_len,
-                                                   const char* ciphersuite)
+static inline unsigned int wolfssl_tls13_server_cb(WOLFSSL* ssl, const char* identity,
+                                                   unsigned char* key, unsigned int key_max_len, 
+                                                   const char** ciphersuite)
 {
         (void)key_max_len;
 

--- a/src/asl.c
+++ b/src/asl.c
@@ -713,7 +713,9 @@ static int wolfssl_configure_endpoint(asl_endpoint* endpoint, asl_endpoint_confi
 
         /* Configure peer authentification */
         int verify_mode = WOLFSSL_VERIFY_NONE;
-        if (config->mutual_authentication == true)
+
+        /* If PSKs are used, mutual authentiation shall not be activated by default */
+        if ((config->mutual_authentication == true) && (config->psk.enable_psk == false))
         {
                 verify_mode = WOLFSSL_VERIFY_PEER | WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT;
         }

--- a/src/asl.c
+++ b/src/asl.c
@@ -780,6 +780,11 @@ asl_endpoint* asl_setup_server_endpoint(asl_endpoint_configuration const* config
                 /* Set wolfSSL internal PSK call-back (not passed to the user) */
                 wolfSSL_CTX_set_psk_server_tls13_callback(new_endpoint->wolfssl_context, wolfssl_tls13_server_cb);
                 
+                if(wolfSSL_CTX_use_psk_identity_hint(new_endpoint->wolfssl_context, "asl server") != WOLFSSL_SUCCESS)
+                {
+                        ERROR_OUT(ASL_INTERNAL_ERROR, "Failed to set psk identity hint");
+                }
+
                 /* Set asl call-back, to reference user implementation */
                 new_endpoint->psk.psk_server_cb = config->psk.psk_server_cb;
                 

--- a/src/asl.c
+++ b/src/asl.c
@@ -301,20 +301,23 @@ done:
 #endif /* HAVE_SECRET_CALLBACK */
 
 #ifndef NO_PSK
-static inline unsigned int wolfssl_tls13_client_cb(WOLFSSL* ssl, const char* hint, 
-                                                   char* identity, unsigned int id_max_len,
-                                                   unsigned char* key, unsigned int key_max_len,
+static inline unsigned int wolfssl_tls13_client_cb(WOLFSSL* ssl,
+                                                   const char* hint,
+                                                   char* identity,
+                                                   unsigned int id_max_len,
+                                                   unsigned char* key,
+                                                   unsigned int key_max_len,
                                                    const char* ciphersuite)
 {
-        (void)hint;
-        (void)key_max_len;
-        (void)id_max_len;
-        (void)ciphersuite;
+        (void) hint;
+        (void) key_max_len;
+        (void) id_max_len;
+        (void) ciphersuite;
 
         uint8_t key_len = 0;
-        
+
         asl_psk_client_callback_t asl_cb = wolfSSL_get_psk_callback_ctx(ssl);
-        if(asl_cb != NULL)
+        if (asl_cb != NULL)
         {
                 key_len = asl_cb(key, identity);
         }
@@ -327,16 +330,18 @@ static inline unsigned int wolfssl_tls13_client_cb(WOLFSSL* ssl, const char* hin
         return key_len;
 }
 
-static inline unsigned int wolfssl_tls13_server_cb(WOLFSSL* ssl, const char* identity,
-                                                   unsigned char* key, unsigned int key_max_len, 
+static inline unsigned int wolfssl_tls13_server_cb(WOLFSSL* ssl,
+                                                   const char* identity,
+                                                   unsigned char* key,
+                                                   unsigned int key_max_len,
                                                    const char** ciphersuite)
 {
-        (void)key_max_len;
+        (void) key_max_len;
 
         uint8_t key_len = 0;
-        
+
         asl_psk_server_callback_t asl_cb = wolfSSL_get_psk_callback_ctx(ssl);
-        if(asl_cb != NULL)
+        if (asl_cb != NULL)
         {
                 key_len = asl_cb(key, identity, ciphersuite);
         }
@@ -774,20 +779,22 @@ asl_endpoint* asl_setup_server_endpoint(asl_endpoint_configuration const* config
                 ERROR_OUT(ASL_INTERNAL_ERROR, "Failed to configure new TLS server context");
 
         /* Set wolSSL pre-shared key callbacks, if enable_psk flag is set. */
-        if(config->psk.enable_psk)
+        if (config->psk.enable_psk)
         {
 #ifndef NO_PSK
                 /* Set wolfSSL internal PSK call-back (not passed to the user) */
-                wolfSSL_CTX_set_psk_server_tls13_callback(new_endpoint->wolfssl_context, wolfssl_tls13_server_cb);
-                
-                if(wolfSSL_CTX_use_psk_identity_hint(new_endpoint->wolfssl_context, "asl server") != WOLFSSL_SUCCESS)
+                wolfSSL_CTX_set_psk_server_tls13_callback(new_endpoint->wolfssl_context,
+                                                          wolfssl_tls13_server_cb);
+
+                if (wolfSSL_CTX_use_psk_identity_hint(new_endpoint->wolfssl_context, "asl server") !=
+                    WOLFSSL_SUCCESS)
                 {
                         ERROR_OUT(ASL_INTERNAL_ERROR, "Failed to set psk identity hint");
                 }
 
                 /* Set asl call-back, to reference user implementation */
                 new_endpoint->psk.psk_server_cb = config->psk.psk_server_cb;
-                
+
                 /* To avoid ambiguity, we set the PSK client callback here to NULL */
                 new_endpoint->psk.psk_client_cb = NULL;
 #else
@@ -888,15 +895,16 @@ asl_endpoint* asl_setup_client_endpoint(asl_endpoint_configuration const* config
                 ERROR_OUT(ASL_INTERNAL_ERROR, "Failed to configure new TLS client context");
 
         /* Set wolSSL pre-shared key callbacks, if enable_psk flag is set. */
-        if(config->psk.enable_psk)
+        if (config->psk.enable_psk)
         {
 #ifndef NO_PSK
                 /* Set wolfSSL internal PSK call-back (not passed to the user) */
-                wolfSSL_CTX_set_psk_client_cs_callback(new_endpoint->wolfssl_context, wolfssl_tls13_client_cb);
-                
+                wolfSSL_CTX_set_psk_client_cs_callback(new_endpoint->wolfssl_context,
+                                                       wolfssl_tls13_client_cb);
+
                 /* Set asl call-back, to reference user implementation */
                 new_endpoint->psk.psk_client_cb = config->psk.psk_client_cb;
-                
+
                 /* To avoid ambiguity, we set the PSK server callback here to NULL */
                 new_endpoint->psk.psk_server_cb = NULL;
 #else
@@ -1046,7 +1054,7 @@ asl_session* asl_create_session(asl_endpoint* endpoint, int socket_fd)
         new_session->handshake_metrics.rx_bytes = 0;
 
 #ifndef NO_PSK
-        if(endpoint->psk.psk_client_cb != NULL)
+        if (endpoint->psk.psk_client_cb != NULL)
         {
                 /* Set client call-back reference in the WOLFSSL* ssl object */
                 wolfSSL_set_psk_callback_ctx(new_session->wolfssl_session, endpoint->psk.psk_client_cb);
@@ -1063,7 +1071,6 @@ asl_session* asl_create_session(asl_endpoint* endpoint, int socket_fd)
                 ERROR_OUT(ASL_PSK_ERROR, "no callback function was set for the endpoint");
         }
 #endif
-
 
         /* Store the socket fd */
         wolfSSL_set_fd(new_session->wolfssl_session, socket_fd);


### PR DESCRIPTION
Pull request to integrate PSK functionality into the main branch of the repository. 
Key changes to the asl library are listed as follows:

### **New structures:**
- callback definitions for **asl_psk_callback** functions, which are set and implemented by the user 

### **Modified structures:**
- modification of the **asl_endpoint_configuration** struct to contain PSK struct with callback references
- modification of the **asl_endpoint** struct to contain PSK callback function references
- modification of **ASL_ERROR_CODES** struct to contain error code for PSK errors

----------------------------------------------------------------------------------------------------------------------------------------------------------------------------

### **New methods:**
- implementation of **wolfssl_psk_callback** functions for server and client 

### **Modified methods:**
- modification of **setup_client_endpoint** and **setup_server_endpoint** function to set up PSK functionality in the wolfssl lib, if enabled
-  modified **asl_default_config** function to set references in the config to NULL and enable flag to FALSE

----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
### **Other:**
- set **KRITIS3M_ASL_ENABLE_FALCON** to OFF to temporary disable dependency to liboqs
- fixed typos in the commentary  