### PR TITLE
Implementation for management of the new TLS 1.3 extension in kritis3m_asl

### DIFF
--- a/include/asl.h
+++ b/include/asl.h
@@ -121,6 +121,7 @@ typedef struct
                 asl_psk_server_callback_t psk_server_cb;
                 bool enable_psk;
                 bool use_external_callbacks;
+                bool enable_certWithExternPsk;
                 void* callback_ctx;
 
         } psk;

--- a/src/asl_general.c
+++ b/src/asl_general.c
@@ -68,6 +68,7 @@ asl_endpoint_configuration asl_default_endpoint_config(void)
         default_config.psk.psk_client_cb = NULL;
         default_config.psk.psk_server_cb = NULL;
         default_config.psk.callback_ctx = NULL;
+        default_config.psk.enable_certWithExternPsk = false;
 
         return default_config;
 }

--- a/src/asl_psk.c
+++ b/src/asl_psk.c
@@ -326,10 +326,13 @@ int psk_setup_general(asl_endpoint* endpoint, asl_endpoint_configuration const* 
         #ifdef WOLFSSL_CERT_WITH_EXTERN_PSK
         /* If configured in the WOLFSSL usersettings, we can activate the extension for certificates in 
          * addition to the PSKs. */
-        ret = wolfSSL_CTX_set_cert_with_extern_psk(endpoint->wolfssl_context, config->psk.enable_certWithExternPsk);
+        endpoint->psk.enable_certWithExternPsk = config->psk.enable_certWithExternPsk;
+         ret = wolfSSL_CTX_set_cert_with_extern_psk(endpoint->wolfssl_context, config->psk.enable_certWithExternPsk);
         if(ret != WOLFSSL_SUCCESS)
                 goto cleanup;
         #endif
+        
+        return ASL_SUCCESS;
 
 cleanup:
         return ret;

--- a/src/asl_psk.c
+++ b/src/asl_psk.c
@@ -323,6 +323,14 @@ int psk_setup_general(asl_endpoint* endpoint, asl_endpoint_configuration const* 
                 ERROR_OUT(ASL_ARGUMENT_ERROR,
                           "Either a PSK master key or external callbacks must be used");
 
+        #ifdef WOLFSSL_CERT_WITH_EXTERN_PSK
+        /* If configured in the WOLFSSL usersettings, we can activate the extension for certificates in 
+         * addition to the PSKs. */
+        ret = wolfSSL_CTX_set_cert_with_extern_psk(endpoint->wolfssl_context, config->psk.enable_certWithExternPsk);
+        if(ret != WOLFSSL_SUCCESS)
+                goto cleanup;
+        #endif
+
 cleanup:
         return ret;
 #else

--- a/src/priv_include/asl_types.h
+++ b/src/priv_include/asl_types.h
@@ -54,6 +54,9 @@ struct asl_endpoint
                 char* master_key;
                 void* callback_ctx;
                 bool use_external_callbacks;
+#ifdef WOLFSSL_CERT_WITH_EXTERN_PSK
+                bool enable_certWithExternPsk;
+#endif
         } psk;
 #endif
 


### PR DESCRIPTION
### Implementation for management of the new TLS 1.3 extension in kritis3m_asl.
Changes to the kritis3m_asl library are listed as follows:

### New structures:
- none

---

### Modified Structures:
- new boolean value in asl_endpoint_configuration.psk struct to enable certificates.
- new boolean value in asl_endpoint.psk struct to enable certificates.
---

### New Methods:
- none

---

### Modified Methods:
- set default value for new enable_certWithExternPsk to false.
- implemented functionality in psk_setup_general() to update enable_certWithExternPsk state in the endpoint and configure WOLFSSL_CTX accordingly.

---

### Other:
- none