### PR TITLE
Adjustable (EC)DHE Secret Establishment in Combination with PSKs

### DIFF
--- a/include/asl.h
+++ b/include/asl.h
@@ -117,6 +117,7 @@ typedef struct
         struct
         {
                 bool enable_psk;
+                bool enable_dhe_psk;
                 bool enable_cert_auth;
                 bool use_external_callbacks;
 

--- a/src/asl_general.c
+++ b/src/asl_general.c
@@ -69,6 +69,7 @@ asl_endpoint_configuration asl_default_endpoint_config(void)
         default_config.keylog_file = NULL;
 
         default_config.psk.enable_psk = false;
+        default_config.psk.enable_dhe_psk = true;
         default_config.psk.use_external_callbacks = false;
         default_config.psk.enable_cert_auth = true;
         default_config.psk.key = NULL;

--- a/src/asl_psk.c
+++ b/src/asl_psk.c
@@ -389,8 +389,17 @@ int psk_setup_general(asl_endpoint* endpoint, asl_endpoint_configuration const* 
         uint8_t key_raw[128] = {0};
         word32 key_len = sizeof(key_raw);
 
-        /* Only allow PSK together with an ephemeral key exchange */
-        wolfSSL_CTX_only_dhe_psk(endpoint->wolfssl_context);
+        /* setup PSK combination with (EC)DHE key gen. */
+        if(config->psk.enable_dhe_psk)
+        {
+                /* PSK + (EC)DHE */
+                wolfSSL_CTX_only_dhe_psk(endpoint->wolfssl_context);
+        }
+        else
+        {
+                /* PSK only */
+                wolfSSL_CTX_no_dhe_psk(endpoint->wolfssl_context);
+        }
 
         if (config->psk.key != NULL)
         {


### PR DESCRIPTION
As part of the publication, it is necessary to be able to deactivate the **(EC)DHE** secret. The new changes create a flag in the TLS `endpoint_config` for the KRITIS3M applications, which makes the **ECDHE + PSK** configuration customizable.

### Modifications 
- new boolean parameter in psk-config  `enable_dhe_psk`
- adjusted `default_config` to set enable_dhe_psk  to **true**
- depending on state of the flag configure wolfssl_config in `psk_setup_general()` function