### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KRITIS³M Agile Security Library
 
-This repository contains the code for the Agile Security Library (ASL), a wrapper library to simplify integration of TLS into applications via a generic and flexble interface to improve Crypto-Agility.
+This repository contains the code for the Agile Security Library (ASL), a wrapper library to simplify integration of TLS into applications via a generic and flexible interface to improve Crypto-Agility.
 
 ## Building
 


### PR DESCRIPTION
Hi Tobi, 
upon checking something in the ASL, I noticed a small typo in the README.md. I hope, it's okay to propose the change as a PR, otherwise just delete this one and fix it in the main-branch :)
The changes in the README are:
- Corrected the spelling of `'flexble'` to `'flexible'` in the README.

Sincerely, 

Lukas 